### PR TITLE
Feature/fix alarms

### DIFF
--- a/alarms/alarms.py
+++ b/alarms/alarms.py
@@ -65,6 +65,7 @@ def read_settings():
     expected_elements = (
         'smtp_host', 'db_host', 'log_file_name', 'db_name',
         'reader_user', 'reader_pw', 'alarm_user', 'alarm_pw',
+        'error_contact_email', 'mail_sender'
     )
     system_global = xml.etree.ElementTree.ElementTree()
     system_global.parse('global_settings.xml')
@@ -147,7 +148,7 @@ class CheckAlarms(object):
             passwd=SETTINGS['alarm_pw'],
         )
         self._reader_cursor = _db.cursor()
-        self._smtp_server_address = SETTINGS['db_host']
+        self._smtp_server_address = SETTINGS['smtp_host']
 
     def _get_alarms(self):
         """Get the list of alarms to check"""
@@ -452,7 +453,7 @@ class CheckAlarms(object):
                     ).format(repr(exp), arguments)
                 body = message + body
 
-        sender = 'Floormanagers@fysik.dtu.dk' # 'no-reply@fysik.dtu.dk'
+        sender = SETTINGS['mail_sender']
         msg = MIMEText(body)
         # Header info
         msg['Subject'] = subject
@@ -506,7 +507,7 @@ def main():
         _LOG.exception("An error occoured during alarm script")
         check_alarms._send_email("Alarm script generated error",
                                  str(exp.args),
-                                 ['jejsor@fysik.dtu.dk'])
+                                 [SETTINGS['error_contact_email']])
 
     _LOG.debug('Execution time: {0}'.format(time.time() - start_time))
 

--- a/alarms/alarms.py
+++ b/alarms/alarms.py
@@ -211,7 +211,7 @@ class CheckAlarms(object):
                 # When the recipients JSON is broken, we cannot send them an
                 # email about it! Send it to Robert and Kenneth instead.
                 if 'recipients' not in alarm:
-                    alarm['recipients'] = ['pyexplabsys-error@fysik.dtu.dk']
+                    alarm['recipients'] = [SETTINGS['error_contact_email']]
                     subject = 'Error in parsing recipients alarm JSON'
                     body += '\n\nTHIS EMAIL WAS ONLY SENT TO YOU'
                 else:

--- a/alarms/alarms.py
+++ b/alarms/alarms.py
@@ -75,6 +75,8 @@ def read_settings():
     for child in system_global:
         if child.tag == 'mail_alarm_settings':
             break
+    else:
+       return settings
     for element in child:
         if element.tag in expected_elements:
             settings[element.tag] = element.text

--- a/alarms/alarms.py
+++ b/alarms/alarms.py
@@ -37,6 +37,7 @@ import os
 import sys
 import json
 import time
+import pathlib
 import smtplib
 from email.mime.text import MIMEText
 from collections import defaultdict, namedtuple
@@ -68,7 +69,8 @@ def read_settings():
         'error_contact_email', 'mail_sender'
     )
     system_global = xml.etree.ElementTree.ElementTree()
-    system_global.parse('global_settings.xml')
+    conf = pathlib.Path(__file__).resolve().parent.parent / 'global_settings.xml'
+    system_global.parse(conf)
     system_global = system_global.getroot()
 
     for child in system_global:

--- a/alarms/alarms.py
+++ b/alarms/alarms.py
@@ -34,13 +34,12 @@ q0 < v0 and q1 > v1
 
 import re
 import os
-import sys
 import json
 import time
 import pathlib
 import smtplib
 from email.mime.text import MIMEText
-from collections import defaultdict, namedtuple
+from collections import defaultdict
 import logging
 from logging.handlers import RotatingFileHandler
 import numpy as np
@@ -161,8 +160,9 @@ class CheckAlarms(object):
         # Column names needs to be excaped with backticks, because
         # someone was stupid enough to pick one which is a reserved
         # word (check)
-        fields_string =' ,'.join(['`{0}`'.format(field) for field in fields])
-        query = 'SELECT {0} FROM alarm WHERE visible=1 AND active=1'.format(fields_string)
+        fields_string = ' ,'.join(['`{0}`'.format(field) for field in fields])
+        query = 'SELECT {0} FROM alarm WHERE visible = 1 AND active = 1'
+        query = query.format(fields_string)
         self._alarm_cursor.execute(query)
 
         # Turns column names and rows into dict and decode json
@@ -205,7 +205,7 @@ class CheckAlarms(object):
             if 'error' in alarm:
                 # Send email about error parsing the json
                 body = (
-                    'At least one error occurred while trying to parse the '\
+                    'At least one error occurred while trying to parse the '
                     'alarm. The error message(s) was:{0}\n\n'
                     'The entire (half parsed) alarm definition was:\n\n{1}'
                 ).format(alarm['error'], dict(alarm))
@@ -254,8 +254,9 @@ class CheckAlarms(object):
                 _LOG.debug("No alarm for check string {0}".format(check_string))
 
     def _check_single_alarm(self, alarm, arguments):
-        _LOG.debug('_check_single_alarm(alarm={0}, arguments={1}")'\
-                       .format(alarm, arguments))
+        _LOG.debug(
+            '_check_single_alarm(alarm={0}, arguments={1}")'.format(alarm, arguments)
+        )
 
         # Check whether all parts of the check was understood
         check_tokens = alarm['check_tokens']
@@ -302,7 +303,10 @@ class CheckAlarms(object):
         last_alarm_time = self._get_time_of_last_alarm(alarm['id'])
 
         # Alarm is not inhibited by no_repeat_interval
-        if last_alarm_time is None or time.time() - last_alarm_time > alarm['no_repeat_interval']:
+        if (
+                last_alarm_time is None or
+                time.time() - last_alarm_time > alarm['no_repeat_interval']
+        ):
             if last_alarm_time is None:
                 _LOG.debug('No previous alarm within no_repeat_interval. '
                            'No previous alarm.')
@@ -503,7 +507,6 @@ def main():
         _LOG.debug('Writing pid file with pid: {0}'.format(pid))
         file_.write(str(pid))
 
-
     check_alarms = CheckAlarms()
     try:
         check_alarms.check_alarms()
@@ -514,6 +517,7 @@ def main():
                                  [SETTINGS['error_contact_email']])
 
     _LOG.debug('Execution time: {0}'.format(time.time() - start_time))
+
 
 if __name__ == '__main__':
     main()

--- a/common_functions_v2.php
+++ b/common_functions_v2.php
@@ -1,15 +1,28 @@
 <?php
+// TODO: Remove this hard-coded timezone
 date_default_timezone_set("Europe/Copenhagen");
 
 /** Returns a handle to the standard database
     @return object 
   */
-function std_db(){
+function std_db($user_type=NULL){
+  // These two xml files will be merged in an upcomming PR
   $xml=simplexml_load_file("../site_settings.xml");
+  $global_settings=simplexml_load_file("../global_settings.xml");
+
+  if ($user_type == 'alarm_user'){
+    $db_user = $global_settings->mail_alarm_settings->alarm_user;
+    $db_password = $global_settings->mail_alarm_settings->alarm_pw;
+  } else {
+    $db_user = $xml->db_user;
+    $db_password = $xml->db_password;
+  }
+
   $conn_str = 'mysql:host=' . $xml->db_host . ';dbname=' . $xml->db_database . ';charset=utf8';
-  $pdo = new PDO($conn_str, $xml->db_user, $xml->db_password);
+  $pdo = new PDO($conn_str, $db_user, $db_password);
   return $pdo;
 }
+
 
 function single_sql_value($db, $query, $column){
     $stmt = $db->prepare($query);

--- a/global_settings.xml
+++ b/global_settings.xml
@@ -1,4 +1,0 @@
-<?xml version='1.0' standalone='yes'?>
-<global_settings>
-  <sort_dataset_by_column>time</sort_dataset_by_column>
-</global_settings>

--- a/other/alarms.php
+++ b/other/alarms.php
@@ -443,15 +443,15 @@ function delete_alarm($alarm_number){
   # If the data is insufficient, set the screen message and return
   $query = "UPDATE alarm SET visible=0 WHERE `id`=?";
   $statement = $db->prepare($query);
-  $statement->bind_param('i', $alarm_number);
+  $statement->bindParam(1, $alarm_number, PDO::PARAM_INT);
+
   if($statement->execute()){
-    $message_out = "<p>Alarm " . $data["id"] . " successfully deleted</p>";
+    $message_out = "<p>Alarm " . $alarm_number . " successfully deleted</p>";
   } else {
     $message_out = msg("The following error occurred while trying to delete " .
-		       "the alarm: (" . $mysqli->errno . ") " . $mysqli->error,
+		       "the alarm: " . $db->errorInfo(),
 		       $alarm=true);
   }
-  $statement->close();
 
 }
 

--- a/other/alarms.php
+++ b/other/alarms.php
@@ -485,30 +485,26 @@ function update_existing(){
     "WHERE `id`=?";
 
   $statement = $db->prepare($query);
-
-  # bind parameters for markers, where (s = string, i = integer, d = double,
-  #                                     b = blob)
   $data["id"] = (int) $data["id"];
   $data["active"] = (int) $data["active"];
-  $statement->bind_param('sssissssii',
-			 $data["quiries_json"],
-			 $data["parameters_json"],
-			 $data["check"],
-			 $data["no_repeat_interval"],
-			 $data["message"],
-			 $data["recipients_json"],
-			 $data["description"],
-			 $data["subject"],
-			 $data["active"],
-			 $data["id"]);
+  $statement->bindParam(1, $data["quiries_json"], PDO::PARAM_STR);
+  $statement->bindParam(2, $data["parameters_json"], PDO::PARAM_STR);
+  $statement->bindParam(3, $data["check"], PDO::PARAM_STR);
+  $statement->bindParam(4, $data["no_repeat_interval"], PDO::PARAM_INT);
+  $statement->bindParam(5, $data["message"], PDO::PARAM_STR);
+  $statement->bindParam(6, $data["recipients_json"], PDO::PARAM_STR);
+  $statement->bindParam(7, $data["description"], PDO::PARAM_STR);
+  $statement->bindParam(8, $data["subject"], PDO::PARAM_STR);
+  $statement->bindParam(9, $data["active"], PDO::PARAM_INT);
+  $statement->bindParam(10, $data["id"], PDO::PARAM_INT);
+
   if($statement->execute()){
     $message_out = "<p>Alarm " . $data["id"] . " was successfully updated</p>";
   } else {
     $message_out = msg("The following error occurred while trying to update " .
-		       "the alarm: (" . $mysqli->errno . ") " . $mysqli->error,
+		       "the alarm: " . $db->errorInfo(),
 		       $alarm=true);
   }
-  $statement->close();
 
   return true;
 }
@@ -568,9 +564,11 @@ if ($action == "new"){
 } elseif ($action == "continue edit"){
   echo("<h1><a id=\"edit_alarm\"></a>Edit alarm number $alarm_number</h1>\n");
   edit_table($action);
-} else {
+} elseif (strpos('edit+', $action) > -1)  {
   echo("<h1><a id=\"edit_alarm\"></a>Edit alarm number $alarm_number</h1>\n");
   edit_table($alarm_data[$alarm_number]);
+} else {
+ // Do nothing
 }
 
 echo("\n\n\n");

--- a/other/alarms.php
+++ b/other/alarms.php
@@ -196,9 +196,9 @@ function edit_table($row){
     $alarm_id = isset($_GET["alarm_id"]) ? $_GET["alarm_id"] : null;
     $check = isset($_GET["check"]) ? $_GET["check"] : "";
     $no_repeat_interval = isset($_GET["no_repeat_interval"]) ? $_GET["no_repeat_interval"] : 3600;
-    $quiries = isset($_GET["quiries"]) ? $_GET["quiries"] : array_fill(0, NUM_INPUTS, "");
-    $recipients = isset($_GET["recipients"]) ? $_GET["recipients"] : array_fill(0, NUM_INPUTS, "");
-    $parameters = isset($_GET["parameters"]) ? $_GET["parameters"] : array_fill(0, NUM_INPUTS, "");
+    $quiries = isset($_GET["quiries"]) ? $_GET["quiries"] : array_fill(0, NUM_INPUTS + 1, "");
+    $recipients = isset($_GET["recipients"]) ? $_GET["recipients"] : array_fill(0, NUM_INPUTS + 1, "");
+    $parameters = isset($_GET["parameters"]) ? $_GET["parameters"] : array_fill(0, NUM_INPUTS + 1, "");
     $message = isset($_GET["message"]) ? $_GET["message"] : "";
     $description = isset($_GET["description"]) ? $_GET["description"] : "";
     $subject = isset($_GET["subject"]) ? $_GET["subject"] : "";
@@ -207,9 +207,9 @@ function edit_table($row){
     $alarm_id = null;
     $check = "";
     $no_repeat_interval = 3600;
-    $quiries = array_fill(0, NUM_INPUTS, "");
-    $recipients = array_fill(0, NUM_INPUTS, "");
-    $parameters = array_fill(0, NUM_INPUTS, "");
+    $quiries = array_fill(0, NUM_INPUTS + 1, "");
+    $recipients = array_fill(0, NUM_INPUTS + 1, "");
+    $parameters = array_fill(0, NUM_INPUTS + 1, "");
     $message = "";
     $description = "";
     $subject = "";

--- a/other/alarms.php
+++ b/other/alarms.php
@@ -6,8 +6,7 @@ include("../common_functions_v2.php");
 // Todo: Either investigate if license allows bundling, or find a version with a cdn
 require("SqlFormatter.php");
 
-// $dbi = std_dbi("alarm");
-$db = std_db();
+$db = std_db($user='alarm_user');
 
 # Holds the data on existing alarms
 $alarm_data = Array();

--- a/template_global_settings.xml
+++ b/template_global_settings.xml
@@ -1,0 +1,16 @@
+<?xml version='1.0' standalone='yes'?>
+<global_settings>
+  <sort_dataset_by_column>time</sort_dataset_by_column>
+  <mail_alarm_settings>
+    <smtp_host>smtp.com</smtp_host>
+    <db_host>127.0.0.1</db_host>
+    <db_name>DBNAME</db_name>
+    <reader_user>reader</reader_user>
+    <reader_pw>reader</reader_pw>
+    <alarm_user>mail_alarm</alarm_user>
+    <alarm_pw>mail_alarm</alarm_pw>
+    <log_file_name>/var/www/html/cinfdata/alarms/alarm_log.txt</log_file_name>
+    <error_contact_email>mail@mail.com</error_contact_email>
+    <mail_sender>operator@mail.com</mail_sender>
+  </mail_alarm_settings>
+</global_settings>


### PR DESCRIPTION
Allow the email alarm script to run in a slightly more modern setting, than where it was born.

PR includes 
 * Updates of deprecated syntax
 * Removal of python2 support 
 * A number of hard-coded values has been moved to settings

The file `global_settings.xml` that historically contained very little information, is now extensively used to keep the values that was previously hard coded. A template file is provided.