### PR TITLE
Feature/multiple as functions ofs

### DIFF
--- a/other/alarms.php
+++ b/other/alarms.php
@@ -425,6 +425,17 @@ function insert_new(){
 		       "trying to insert the new alarm: " . $db->errorInfo(),
 		       $alarm=true);
   }
+
+  // If this is a purchase reminder, insert first dateplot row
+  if (str_contains($data["description"], "[purchase_reminders]")){
+    $query = "INSERT INTO dateplots_purchase_reminders (type, value) values (:i, :v)";
+    $stmt = $db->prepare($query);
+    $stmt->bindValue(':i', $latest_id);
+    $stmt->bindValue(':v', 0);
+    $stmt->execute();
+  }
+
+
   return true;
 }
 

--- a/other/order.php
+++ b/other/order.php
@@ -2,16 +2,10 @@
 include("../common_functions_v2.php");
 echo(html_header());
 
-// purchase_reminders
-// dateplots_purchase_reminders
-
 $id = intval($_GET["id"] ?? 0);
 $action = trim(strtolower(htmlspecialchars($_GET["action"] ?? '')));
-//$id = 26;
-//$action = 'reset';
 
-$db = std_db();
-// $db = std_db($user='alarm_user');
+$db = std_db($user='alarm_user');
 
 
 /** Produces the HTML for the existing purchase_reminders */
@@ -19,7 +13,6 @@ function existing_purchase_reminders(){
   global $db;
 
   # Get the alarms
-  // $query = "SELECT * FROM alarm WHERE visible=1 order by id";
   $query = "SELECT id, description FROM alarm WHERE description like \"[purchase_reminders]%\"";
   $result = $db->query($query);
 
@@ -90,11 +83,8 @@ if ($action=='qr'){
   echo("<img src=\"../figures/qr_{$id}.png\">\n");
 }
 
-
 // Print the overview
-
 existing_purchase_reminders();
-
 
 echo("\n\n\n");
 echo(html_footer());

--- a/other/order.php
+++ b/other/order.php
@@ -73,7 +73,8 @@ if ($action === 'reset'){
 
 if ($action=='qr'){
   ob_start();
-  $command = './qr_generator.py ' . $id;
+  $url = $_SERVER['HTTP_HOST'] . $_SERVER['PHP_SELF'];
+  $command = './qr_generator.py ' . $id . ' ' . $url;
   passthru($command, $return_code);
   $content_grabbed=ob_get_contents();
   ob_end_clean();

--- a/other/order.php
+++ b/other/order.php
@@ -1,0 +1,102 @@
+<?php
+include("../common_functions_v2.php");
+echo(html_header());
+
+// purchase_reminders
+// dateplots_purchase_reminders
+
+$id = intval($_GET["id"] ?? 0);
+$action = trim(strtolower(htmlspecialchars($_GET["action"] ?? '')));
+//$id = 26;
+//$action = 'reset';
+
+$db = std_db();
+// $db = std_db($user='alarm_user');
+
+
+/** Produces the HTML for the existing purchase_reminders */
+function existing_purchase_reminders(){
+  global $db;
+
+  # Get the alarms
+  // $query = "SELECT * FROM alarm WHERE visible=1 order by id";
+  $query = "SELECT id, description FROM alarm WHERE description like \"[purchase_reminders]%\"";
+  $result = $db->query($query);
+
+  # Start the table
+  echo("<div style=\"width:45%;float:left\">");
+  echo("<h1><a id=\"existing\"></a>Existing ordering items</h1>\n");
+  echo("<table border=\"1\" class=\"nicetable\">\n");
+  echo("\n<tr>\n");
+  echo("<th>ID</th>\n<th>Description</th>\n<th>Value</th>\n<th colspan=3>Actions</th>\n");
+  echo("</tr>");
+
+  # Loop over alarms
+  while($row = $result->fetch()) {
+
+    $query = "select unix_timestamp(time), value from dateplots_purchase_reminders where type=" . $row[0] . " order by id desc limit 1";
+    // $latest_time = single_sql_value($db, $query, 0); Not really needed for now
+    $latest_value = single_sql_value($db, $query, 1);
+
+    echo("\n\n<tr>\n");
+    echo("<td>{$row[0]}</td>\n");
+    echo("<td>{$row[1]}</td>\n");
+    echo("<td>$latest_value</td>\n");
+    echo("<td><a href=\"order.php?id=" . $row[0] . "&action=qr\">QR</a></td>\n");
+    echo("<td><a href=\"order.php?id=" . $row[0] . "&action=reset\">Reset</a></td>\n");
+    echo("<td><a href=\"order.php?id=" . $row[0] . "\">Order</a></td>\n");
+    echo("</tr>");
+  }
+
+  # End the table
+  echo("\n\n</table>\n");
+  echo("</div>\n");
+}
+
+function update_value_in_purchase_reminders($value){
+  global $db;
+  global $id;
+  $query = "INSERT INTO dateplots_purchase_reminders (type, value) values (:i, :v)";
+  $stmt = $db->prepare($query);
+  $stmt->bindValue(':i', $id);
+  $stmt->bindValue(':v', $value);
+  $stmt->execute();
+}
+
+// Handle the given action
+
+if (($action === '') && ($id > 0)){
+  $query = "select unix_timestamp(time), value from dateplots_purchase_reminders where type=" . $id . " order by id desc limit 1";
+  // $latest_time = single_sql_value($db, $query, 0); Not really needed for now
+  $latest_value = single_sql_value($db, $query, 1);
+  update_value_in_purchase_reminders($latest_value + 1);
+  echo("<h1>Thank you for your notifying</h1>\n");
+}
+
+if ($action === 'reset'){
+  update_value_in_purchase_reminders(0);
+  echo("<h1>Thank you for ordering supplies</h1>\n");
+}
+
+if ($action=='qr'){
+  ob_start();
+  $command = './qr_generator.py ' . $id;
+  passthru($command, $return_code);
+  $content_grabbed=ob_get_contents();
+  ob_end_clean();
+  echo($content_grabbed);
+
+  echo("<h1>QR for item {$id}</h1>\n");
+  echo("<img src=\"../figures/qr_{$id}.png\">\n");
+}
+
+
+// Print the overview
+
+existing_purchase_reminders();
+
+
+echo("\n\n\n");
+echo(html_footer());
+
+?>

--- a/other/qr_generator.py
+++ b/other/qr_generator.py
@@ -1,0 +1,30 @@
+#!/usr/bin/python3
+import qrcode
+import argparse
+
+from pathlib import Path
+
+
+def make_qr(order_type: int, url: str):
+    qr = qrcode.QRCode(
+        version=10,
+        error_correction=qrcode.constants.ERROR_CORRECT_H,
+        box_size=20,
+        border=4,
+    )
+    url = 'http://' + url + '?id={}'
+    url = url.format(order_type)
+    qr.add_data(url)
+    qr.make(fit=True)
+    img = qr.make_image(fill_color="black", back_color="white")
+    p = Path.cwd()
+
+    img.save(p.parents[0] / 'figures' / 'qr_{}.png'.format(order_type))
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser('QR generator for cinfdata ordering system')
+    parser.add_argument('id', type=int)
+    parser.add_argument('url', type=str)
+    args = parser.parse_args()
+    make_qr(args.id, args.url)

--- a/sym-files2/databasebackend.py
+++ b/sym-files2/databasebackend.py
@@ -347,6 +347,16 @@ class dataBaseBackend():
         return outstr
 
     def _as_function_of(self):
+        # If several as_function_of's are defined, func_type will tell which one
+        # - in the legacy case of only one, func type will just be the default
+        # value and not match a key - root key is (which is the only one in
+        # the classic case) is then used
+        func_type = self.o['as_function_of']
+        if func_type in self.ggs['as_function_of']:
+            settings = self.ggs['as_function_of'][func_type]
+        else:
+            settings = self.ggs['as_function_of']
+
         # Get the datetime of the measurement
         for dat in self.data['left'] + self.data['right']:
             query = ('SELECT {0} FROM {1} where id = {2}'
@@ -358,7 +368,7 @@ class dataBaseBackend():
 
             # Fetch all sets of id and label that is from the same time
             query = ('SELECT id, {0} FROM {1} WHERE TIME = \"{2}\"'
-                     ''.format(self.ggs['as_function_of']['column'],
+                     ''.format(settings['column'],
                                self.ggs['measurements_table'],
                                timestamp.strftime("%Y-%m-%d %H:%M:%S")))
             measurements = self._result_from_query(query)
@@ -367,8 +377,7 @@ class dataBaseBackend():
             # e.g.: "temperature"
             new_x_id = None
             for measurement in measurements:
-                search = re.search(self.ggs['as_function_of']['reg_match'],
-                                   measurement[1])
+                search = re.search(settings['reg_match'], measurement[1])
                 try:
                     if len(search.group(0)) > 0:
                         new_x_id = measurement[0]
@@ -379,7 +388,7 @@ class dataBaseBackend():
             if new_x_id:
                 # Change the x-axis label
                 self.data['data_treatment']['xlabel'] =\
-                    self.ggs['as_function_of']['xlabel']
+                    settings['xlabel']
                 # Fetch the pertaining temperature data
                 new_x = self.__get_data_xyplot_single(new_x_id)
                 """ Assumes both dat and new_x contains a common

--- a/sym-files2/export_data.py
+++ b/sym-files2/export_data.py
@@ -59,6 +59,10 @@ class ExportData:
         for pair in options.boolean_options.split(',')[1:]:
             key, value = pair.split(':')
             self.o[key] = True if value == 'checked' else False
+            if key == 'as_function_of':
+                if value:
+                    self.o['as_function_of'] = value
+
         # Parse bounds
         bkeys = [s + '_bounding' for s in ['xscale', 'left_yscale', 'right_yscale']]
         for bound in bkeys:
@@ -168,7 +172,7 @@ class ExportData:
             for n, d in enumerate(data['left'] + data['right']):
                 # Only make output if the current warning key is present in the
                 # current datasets graphsettings
-                if d['lgs'].has_key(warning):
+                if warning in d['lgs']:
                     out += ['"' + warning + '"', '"' + d['lgs'][warning] + '"']
                 else:
                     out += ['', '']

--- a/sym-files2/plot.py
+++ b/sym-files2/plot.py
@@ -85,6 +85,10 @@ class Plot():
         for pair in options.boolean_options.split(',')[1:]:
             key, value = pair.split(':')
             self.o[key] = True if value == 'checked' else False
+            if key == 'as_function_of':
+                if value:
+                    self.o['as_function_of'] = value
+
         # Parse bounds
         bkeys = [s + '_bounding' for s in ['xscale', 'left_yscale', 'right_yscale']]
         for bound in bkeys:

--- a/sym-files2/xyplot.php
+++ b/sym-files2/xyplot.php
@@ -237,14 +237,15 @@ if ($matplotlib == 'checked'){
               } else {
                 $show_plot_options = "display:none";
               }
-		    ?>
-		    <span id="plot_options" style="<?php echo($show_plot_options);?>">
-		    <hr>
-		  <?php
-          // Check for specific settings defined in graphsettings.xml and print if defined
+	 ?>
+	 <span id="plot_options" style="<?php echo($show_plot_options);?>">
+	 <hr>
+	 <?php
+         // Check for specific settings defined in graphsettings.xml and print if defined
             if(in_array("flip_x",array_keys($settings)) == "1"){
                echo($settings["flip_x"]["gui"] . "<input type=\"checkbox\" name=\"flip_x\" value=\"checked\"" . $flip_x . "><br>");
             }
+
             if(in_array("as_function_of",array_keys($settings)) == "1"){
                 $checked = "";
                 if ($as_function_of == 'default'){
@@ -252,7 +253,6 @@ if ($matplotlib == 'checked'){
                 }
                 echo($settings["as_function_of"]["gui"] . "<input type=\"checkbox\" name=\"as_function_of\" value=\"default\"" . $checked . "><br>");
             }
-	    # WARNING - THIS NEEDS TO BY CHECKED AND FIXED !!!!! THE OUTER IF IS ENDED TOO SOON!
             foreach ($settings["as_function_of"] as $key => $value){
 		if (is_array($value)){
                     $checked = "";

--- a/sym-files2/xyplot.php
+++ b/sym-files2/xyplot.php
@@ -53,7 +53,7 @@ $right_plotlist    = isset($_GET["right_plotlist"])     ? $_GET["right_plotlist"
 $matplotlib        = isset($_GET["matplotlib"])         ? "checked"                    : "";
 $plot_options      = isset($_GET["plot_options"])       ? "checked"                    : "";
 $flip_x            = isset($_GET["flip_x"])             ? "checked"                    : "";
-$as_function_of    = isset($_GET["as_function_of"])     ? "checked"                    : "";
+$as_function_of    = isset($_GET["as_function_of"])     ? $_GET["as_function_of"]      : "";
 $diff_left_y       = isset($_GET["diff_left_y"])        ? "checked"                    : "";
 $diff_right_y      = isset($_GET["diff_right_y"])       ? "checked"                    : "";
 $linscale_x0       = isset($_GET["linscale_x0"])        ? "checked"                    : "";
@@ -246,8 +246,23 @@ if ($matplotlib == 'checked'){
                echo($settings["flip_x"]["gui"] . "<input type=\"checkbox\" name=\"flip_x\" value=\"checked\"" . $flip_x . "><br>");
             }
             if(in_array("as_function_of",array_keys($settings)) == "1"){
-               echo($settings["as_function_of"]["gui"] . "<input type=\"checkbox\" name=\"as_function_of\" value=\"checked\"" . $as_function_of . "><br>");
+                $checked = "";
+                if ($as_function_of == 'default'){
+                   $checked = "checked";
+                }
+                echo($settings["as_function_of"]["gui"] . "<input type=\"checkbox\" name=\"as_function_of\" value=\"default\"" . $checked . "><br>");
             }
+	    # WARNING - THIS NEEDS TO BY CHECKED AND FIXED !!!!! THE OUTER IF IS ENDED TOO SOON!
+            foreach ($settings["as_function_of"] as $key => $value){
+		if (is_array($value)){
+                    $checked = "";
+                    if ($as_function_of == $key){
+                        $checked = "checked";
+                    }
+                    echo($value["gui"] . "<input type=\"checkbox\" name=\"as_function_of\" value=\"" . $key . "\"" . $checked . "><br>");
+		}
+            }
+
             if(in_array("diff_left_y",array_keys($settings)) == "1"){
                echo($settings["diff_left_y"]["gui"] . "<input type=\"checkbox\" title=\"Assumes equidistant x-spacing!\" name=\"diff_left_y\" value=\"checked\"" . $diff_left_y . "><br>");
             }


### PR DESCRIPTION
This PR adds the possibility of having more than one `as-function-of` in an xy-plot.

If `graphsettings.xml` is left untouched, the old behaviour is retained. To use the new functionality, the syntax in `graphsettings.xml` is as follows:

```
<as_function_of>

      <gui>As function of T</gui>
      <column>label</column>
      <reg_match>VTI Temperature</reg_match>
      <xlabel>VTI Temperature</xlabel>

      <b_field>
        <gui>As function of B</gui>
        <column>label</column>
        <reg_match>B-Field</reg_match>
        <xlabel>B-Field</xlabel>
      </b_field>

 </as_function_of>

```

The first section is the old default syntax, and the following sections (here only a single section named `b_field` is provided) names the extra `as-function-of`'s. 